### PR TITLE
BREAKING CHANGE: Changing Repo to allowing Publishing to PyPI.

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.0 (2024-08-09)
+ * Renaming repo to realit-singer-python to allow required publishing to PyPI
+ * NOTE: Will need to urgently update tap-oracle, tap-mssql, tap-s3-csv which are dependent on this.
+
 ## 4.0.1 (2024-08-08)
  * Correcting Supported Python version constraint in pyproject.toml >=3.8,<3.13
  * Bump pytest from 7.4.4 to 8.3.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
-name = "pipelinewise-singer-python"
-version = "4.0.1"
-description = "Singer.io utility library - PipelineWise compatible"
+name = "realit-singer-python"
+version = "5.0.0"
+description = "Singer.io utility library - PipelineWise and Meltano compatible"
 authors = []
 license = "Apache 2.0"
 readme = "README.md"
-homepage = "https://github.com/s7clarke10/pipelinewise-singer-python"
-repository = "https://github.com/s7clarke10/pipelinewise-singer-python"
+homepage = "https://github.com/s7clarke10/realit-singer-python"
+repository = "https://github.com/s7clarke10/realit-singer-python"
 keywords = ["singer", "meltano", "pipelinewise", "framework"]
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
@@ -83,4 +83,4 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
-pipelinewise-singer-python = "pipelinewise_singer_python.__init__:main"
+realit-singer-python = "realit_singer_python.__init__:main"


### PR DESCRIPTION
# Description of change
BREAKING CHANGE.

Need to rename this repo to allow it to be pushed to PyPI so we can use PyPI dependencies in downstream taps.
 - tap-mssql
 - tap-oracle
 - tap-s3-csv
 - tap-sybase

# Manual QA steps
 - 
 
# Risks
 - Breaking changes to taps until this is urgently pushed through.
 
# Rollback steps
 - revert this branch
